### PR TITLE
Fix path for Windows SpotifyWebHelper.exe

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function generateRandomLocalHostName() {
 function getWebHelperPath() {
 	// possible error: on linux
 	if (process.platform == 'win32')  {
-		return require('user-home') + "AppData\\Roaming\\Spotify\\Data\\SpotifyWebHelper.exe"
+		return require('user-home') + "\\AppData\\Roaming\\Spotify\\SpotifyWebHelper.exe"
 	}
 	else {
 		return require('user-home') + "/Library/Application Support/Spotify/SpotifyWebHelper"


### PR DESCRIPTION
This fixes spotify-web-helper to look in the right place for SpotifyWebHelper.  Two fixes were made:
- A backslash now precedes `AppData`
- The .exe is no longer in the `Data` directory, but in the root of it.
