### PR TITLE
Added status-will-change event, fixed initial events

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ helper.player.on('ready', () => {
 	helper.player.on('pause', () => { });
 	helper.player.on('end', () => { });
 	helper.player.on('track-will-change', track => {});
+	helper.player.on('status-will-change', status => {});
 
 	// Playback control. These methods return promises
 	helper.player.play('spotify:track:213342152345');

--- a/index.js
+++ b/index.js
@@ -257,11 +257,12 @@ function SpotifyWebHelper(opts) {
 			})
 			.then(res => {
 				this.status = res;
+				this.player.emit('ready');
 				this.player.emit('status-will-change', res);
 				if (res.playing) {
 					this.player.emit('play');
 					startSeekingInterval.call(this);
-					this.player.emit('track-change', res.track);
+					this.player.emit('track-will-change', res.track);
 				}
 				resolve();
 			})
@@ -298,7 +299,6 @@ function SpotifyWebHelper(opts) {
 		return getStatus();
 	})
 	.then(() => {
-		this.player.emit('ready');
 		return listen();
 	})
 	.catch(err => this.player.emit('error', err));

--- a/index.js
+++ b/index.js
@@ -221,6 +221,7 @@ function SpotifyWebHelper(opts) {
 		clearInterval(seekingInterval);
 	};
 	this.compareStatus = function (status) {
+		this.player.emit('status-will-change', status);
 		let hasUri = track => track && track.track_resource && track.track_resource.uri;
 		if (hasUri(this.status.track) && hasUri(status.track) && this.status.track.track_resource.uri !== status.track.track_resource.uri) {
 			this.player.emit('track-will-change', status.track);
@@ -256,6 +257,7 @@ function SpotifyWebHelper(opts) {
 			})
 			.then(res => {
 				this.status = res;
+				this.player.emit('status-will-change', res);
 				if (res.playing) {
 					this.player.emit('play');
 					startSeekingInterval.call(this);

--- a/test.js
+++ b/test.js
@@ -15,6 +15,9 @@ helper.player.on('ready', () => {
 	helper.player.on('track-will-change', function (track) {
 		console.log('new track', track);
 	});
+	helper.player.on('status-will-change', function (status) {
+		console.log('updated status', status);
+	});
 	console.log(helper.status);
 	// 'status': {
 	//  	'track': ...,


### PR DESCRIPTION
The status-will-change event will fire for all status changes. This allows for easier GUI updates based on the status object, as well as triggering code for events that are not currently specified as separate events (eg private mode being enabled).

I also found that the initial triggering of events was not working properly, since they were being subscribed to when the ready event was triggered, but this was being emitted after the initial events. Therefore, I moved the firing of the ready event. The track-change event was still being used in this section of the code, so this was also changed.
