### PR TITLE
fix ReferenceError: status is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,7 @@ function SpotifyWebHelper(opts) {
 					this.player.emit('play');
 					startSeekingInterval.call(this);
 					this.player.emit('track-will-change', res.track);
-					let hadListeners = this.player.emit('track-change', status.track);
+					let hadListeners = this.player.emit('track-change', this.status.track);
 					if (hadListeners) {
 						console.log(chalk.yellow(`WARN: 'track-change' was renamed to 'track-will-change'. Please update your listener.`))
 					}


### PR DESCRIPTION
Without this patch, I see this error on initialization:

```
ERROR:  ReferenceError: status is not defined
    at getJSON.then.res (/Users/noah/dev/mixable/node_modules/@jonny/spotify-web-helper/index.js:272:58)
    at process._tickCallback (internal/process/next_tick.js:103:7)
```