### PR TITLE
fix fake OAuth token error

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var START_HTTP_PORT = 4380;
 var END_HTTP_PORT = 4389;
 var RETURN_ON = ['login', 'logout', 'play', 'pause', 'error', 'ap'];
 var DEFAULT_RETURN_AFTER = 60;
+var FAKE_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36';
 
 var ORIGIN_HEADER = {Origin: 'https://open.spotify.com'};
 var KEEPALIVE_HEADER = {Connection: 'keep-alive', Origin: 'https://open.spotify.com'};
@@ -22,6 +23,11 @@ function getJSON(obj) {
 	return new Promise(function (resolve, reject) {
 		if (obj.params) {
 			obj.url += '?' + qs.stringify(obj.params);
+		}
+		if(obj.headers){
+			obj.headers['User-Agent'] = FAKE_USER_AGENT;
+		}else{
+			obj.headers = {'User-Agent': FAKE_USER_AGENT};
 		}
 		request({
 			url: obj.url,

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ function getJSON(obj) {
 		if (obj.params) {
 			obj.url += '?' + qs.stringify(obj.params);
 		}
-		if(obj.headers){
+		if (obj.headers) {
 			obj.headers['User-Agent'] = FAKE_USER_AGENT;
-		}else{
+		} else {
 			obj.headers = {'User-Agent': FAKE_USER_AGENT};
 		}
 		request({


### PR DESCRIPTION
It seems that spotify needs a fake user agent when requesting an oauth token and probably for other requests too. Otherwise you will get something like "NAow[...]vRy**faketoken**"