### PR TITLE
Remove Unnecessary Dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,9 @@ function parseTime(number) {
 
 function getWebHelperPath() {
 	if (process.platform === 'win32') {
-		return require('user-home') + '\\AppData\\Roaming\\Spotify\\SpotifyWebHelper.exe';
+		return path.join(os.homedir(), '\\AppData\\Roaming\\Spotify\\SpotifyWebHelper.exe');
 	}
-	return require('user-home') + '/Library/Application Support/Spotify/SpotifyWebHelper';
+	return path.join(os.homedir(), '/Library/Application Support/Spotify/SpotifyWebHelper');
 }
 
 function isSpotifyWebHelperRunning() {

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 var EventEmitter = require('events').EventEmitter;
 var childProcess = require('child_process');
 var qs = require('querystring');
+var os = require('os');
+var path = require('path');
 var util = require('util');
 var got = require('got');
 var processExists = require('process-exists');
-var chalk = require('chalk');
 
 var spotifyWebHelperWinProcRegex;
 

--- a/index.js
+++ b/index.js
@@ -256,7 +256,10 @@ function SpotifyWebHelper(opts) {
 			this.player.emit('track-will-change', status.track);
 			let hadListeners = this.player.emit('track-change', status.track);
 			if (hadListeners) {
-				console.log(chalk.yellow(`WARN: 'track-change' was renamed to 'track-will-change'. Please update your listener.`))
+				process.emitWarning(
+					'\'track-change\' was renamed to \'track-will-change\', please update your listener',
+					'DeprecationWarning'
+				);
 			}
 		}
 		if (this.status.playing !== status.playing) {
@@ -294,7 +297,10 @@ function SpotifyWebHelper(opts) {
 					this.player.emit('track-will-change', res.track);
 					let hadListeners = this.player.emit('track-change', this.status.track);
 					if (hadListeners) {
-						console.log(chalk.yellow(`WARN: 'track-change' was renamed to 'track-will-change'. Please update your listener.`))
+						process.emitWarning(
+							'\'track-change\' was renamed to \'track-will-change\', please update your listener',
+							'DeprecationWarning'
+						);
 					}
 				}
 				resolve();

--- a/index.js
+++ b/index.js
@@ -257,10 +257,14 @@ function SpotifyWebHelper(opts) {
 			this.player.emit('track-will-change', status.track);
 			let hadListeners = this.player.emit('track-change', status.track);
 			if (hadListeners) {
-				process.emitWarning(
-					'\'track-change\' was renamed to \'track-will-change\', please update your listener',
-					'DeprecationWarning'
-				);
+				if (process.emitWarning) {
+					process.emitWarning(
+						'\'track-change\' was renamed to \'track-will-change\', please update your listener',
+						'DeprecationWarning'
+					);
+				} else {
+					console.warn('DeprecationWarning: \'track-change\' was renamed to \'track-will-change\', please update your listener')
+				}
 			}
 		}
 		if (this.status.playing !== status.playing) {
@@ -298,10 +302,14 @@ function SpotifyWebHelper(opts) {
 					this.player.emit('track-will-change', res.track);
 					let hadListeners = this.player.emit('track-change', this.status.track);
 					if (hadListeners) {
-						process.emitWarning(
-							'\'track-change\' was renamed to \'track-will-change\', please update your listener',
-							'DeprecationWarning'
-						);
+						if (process.emitWarning) {
+							process.emitWarning(
+								'\'track-change\' was renamed to \'track-will-change\', please update your listener',
+								'DeprecationWarning'
+							);
+						} else {
+							console.warn('DeprecationWarning: \'track-change\' was renamed to \'track-will-change\', please update your listener')
+						}
 					}
 				}
 				resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,11 +138,6 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "p-cancelable": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.2.0.tgz",
@@ -227,11 +222,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,11 @@
       "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-1.11.0.tgz",
       "integrity": "sha1-zZLD9JiVo8FZFZEDXL++a1HFWrE="
     },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+    },
     "decompress-response": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.2.0.tgz",
@@ -147,6 +152,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "ndjson": {
       "version": "1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,25 +3,10 @@
   "version": "1.9.0",
   "lockfileVersion": 1,
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -58,11 +43,6 @@
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM="
     },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -87,11 +67,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.0.0.tgz",
       "integrity": "sha1-gtQ59nY82xyIIbejquJ4TIjDuNM="
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "inherits": {
       "version": "2.0.3",
@@ -237,16 +212,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
       "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tasklist": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,11 +23,6 @@
       "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-1.11.0.tgz",
       "integrity": "sha1-zZLD9JiVo8FZFZEDXL++a1HFWrE="
     },
-    "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
-    },
     "decompress-response": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.2.0.tgz",
@@ -127,11 +122,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "ndjson": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/onetune/spotify-web-helper#readme",
   "dependencies": {
     "chalk": "^1.1.3",
+    "debug": "^2.6.8",
     "got": "^7.0.0",
     "process-exists": "^1.0.0",
     "user-home": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/onetune/spotify-web-helper#readme",
   "dependencies": {
-    "debug": "^2.6.8",
     "got": "^7.0.0",
     "process-exists": "^1.0.0",
     "user-home": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/onetune/spotify-web-helper#readme",
   "dependencies": {
-    "chalk": "^1.1.3",
     "debug": "^2.6.8",
     "got": "^7.0.0",
     "process-exists": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "homepage": "https://github.com/onetune/spotify-web-helper#readme",
   "dependencies": {
     "got": "^7.0.0",
-    "process-exists": "^1.0.0",
-    "user-home": "^2.0.0"
+    "process-exists": "^1.0.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Chalk was unnecessary for the small console warning for using an old event name.  Instead we use native `process.emitWarning`.  User-home was pretty much a ponyfill to support `os.homedir` for a node version we don't support anyways.