### PR TITLE
Work with electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ function getJSON(obj) {
 		}
 		got(obj.url, {
 			headers: obj.headers,
-			rejectUnauthorized: false
+			rejectUnauthorized: false,
+			useElectronNet: false
 		}).then(response => {
 			try {
 				resolve(JSON.parse(response.body));


### PR DESCRIPTION
I'm not exactly sure why, but I am unable get the newest versions of spotify-web-helper to work in my electron process unless I set this line.

I used Wireshark to compare the requests in different settings.

Before (in node process):
```
GET /service/version.json?service=remote HTTP/1.1
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
accept-encoding: gzip,deflate
origin: http://open.spotify.com
Host: 127.0.0.1:4370
Connection: close
```

Before (in electron):
```
GET /service/version.json?service=remote HTTP/1.1
Host: 127.0.0.1:4370
Connection: keep-alive
Content-Length: 0
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
accept-encoding: gzip,deflate
origin: http://open.spotify.com
Accept-Language: en-US
```

After (in electron):
```
GET /service/version.json?service=remote HTTP/1.1
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
accept-encoding: gzip,deflate
origin: http://open.spotify.com
Host: 127.0.0.1:4370
Connection: close
```