### PR TITLE
Adds a method to be able to get a fresh status if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ helper.player.on('ready', () => {
 
 #### helper.status
  - `<`[`SpotifyStatus`](#typedef-spotifystatus)`>`
-
+ 
+ Gets the current saved status.
+#### helper.getStatus()
+ - `<`[`SpotifyStatus`](#typedef-spotifystatus)`>`
+ 
+ Refetches the status from Spotify and returns it.
 
 
 ### Class: PlayerEventEmitter ###

--- a/index.js
+++ b/index.js
@@ -15,362 +15,417 @@ var START_HTTP_PORT = 4380;
 var END_HTTP_PORT = 4389;
 var RETURN_ON = ['login', 'logout', 'play', 'pause', 'error', 'ap'];
 var DEFAULT_RETURN_AFTER = 60;
-var FAKE_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36';
+var FAKE_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36';
 
-var ORIGIN_HEADER = {Origin: 'https://open.spotify.com'};
-var KEEPALIVE_HEADER = {Connection: 'keep-alive', Origin: 'https://open.spotify.com'};
+var ORIGIN_HEADER = { Origin: 'https://open.spotify.com' };
+var KEEPALIVE_HEADER = {
+  Connection: 'keep-alive',
+  Origin: 'https://open.spotify.com'
+};
 
 var SEEK_INTERVAL_LENGTH = 250;
 
 function getJSON(obj) {
-    return new Promise(function (resolve, reject) {
-        if (obj.params) {
-            obj.url += '?' + qs.stringify(obj.params);
+  return new Promise(function (resolve, reject) {
+    if (obj.params) {
+      obj.url += '?' + qs.stringify(obj.params);
+    }
+    if (obj.headers) {
+      obj.headers['User-Agent'] = FAKE_USER_AGENT;
+    } else {
+      obj.headers = { 'User-Agent': FAKE_USER_AGENT };
+    }
+    got(obj.url, {
+      headers: obj.headers,
+      rejectUnauthorized: false,
+      useElectronNet: false
+    })
+      .then(response => {
+        try {
+          resolve(JSON.parse(response.body));
+        } catch (err) {
+          reject(err);
         }
-        if (obj.headers) {
-            obj.headers['User-Agent'] = FAKE_USER_AGENT;
-        } else {
-            obj.headers = {'User-Agent': FAKE_USER_AGENT};
-        }
-        got(obj.url, {
-            headers: obj.headers,
-            rejectUnauthorized: false,
-            useElectronNet: false
-        }).then(response => {
-            try {
-                resolve(JSON.parse(response.body));
-            } catch (err) {
-                reject(err);
-            }
-        }).catch(reject);
-    });
+      })
+      .catch(reject);
+  });
 }
 
 function parseTime(number) {
-    let fullseconds = Math.round(number);
-    let minutes = Math.floor(fullseconds / 60);
-    let seconds = fullseconds - (minutes * 60);
-    if (seconds < 10) {
-        seconds = '0' + seconds;
-    }
-    return minutes + ':' + seconds;
+  let fullseconds = Math.round(number);
+  let minutes = Math.floor(fullseconds / 60);
+  let seconds = fullseconds - minutes * 60;
+  if (seconds < 10) {
+    seconds = '0' + seconds;
+  }
+  return minutes + ':' + seconds;
 }
 
 function getWebHelperPath() {
-    if (process.platform === 'win32') {
-        return path.join(os.homedir(), '\\AppData\\Roaming\\Spotify\\SpotifyWebHelper.exe');
-    }
-    return path.join(os.homedir(), '/Library/Application Support/Spotify/SpotifyWebHelper');
+  if (process.platform === 'win32') {
+    return path.join(
+      os.homedir(),
+      '\\AppData\\Roaming\\Spotify\\SpotifyWebHelper.exe'
+    );
+  }
+  return path.join(
+    os.homedir(),
+    '/Library/Application Support/Spotify/SpotifyWebHelper'
+  );
 }
 
 function isSpotifyWebHelperRunning() {
-    return new Promise(function (resolve, reject) {
-        if (process.platform === 'darwin') {
-            return processExists('SpotifyWebHelper', function (err, exists) {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(exists);
-                }
-            });
-        } else if (process.platform === 'win32') {
-            var ps = require('./lib/wintools-ps');
-
-            ps(function (err, lst) {
-                if (err) {
-                    return reject(err);
-                }
-                spotifyWebHelperWinProcRegex = spotifyWebHelperWinProcRegex || new RegExp('spotifywebhelper.exe', 'i');
-
-                for (var k in lst) {
-                    if (spotifyWebHelperWinProcRegex.test(lst[k].desc)) {
-                        return resolve(true);
-                    }
-                    spotifyWebHelperWinProcRegex.lastIndex = 0;
-                }
-                return resolve(false);
-            });
+  return new Promise(function (resolve, reject) {
+    if (process.platform === 'darwin') {
+      return processExists('SpotifyWebHelper', function (err, exists) {
+        if (err) {
+          reject(err);
         } else {
-            // SpotifyWebHelper starts with Spotify by default in Linux
-            return resolve(true);
+          resolve(exists);
         }
-    });
+      });
+    } else if (process.platform === 'win32') {
+      var ps = require('./lib/wintools-ps');
+
+      ps(function (err, lst) {
+        if (err) {
+          return reject(err);
+        }
+        spotifyWebHelperWinProcRegex =
+          spotifyWebHelperWinProcRegex ||
+          new RegExp('spotifywebhelper.exe', 'i');
+
+        for (var k in lst) {
+          if (spotifyWebHelperWinProcRegex.test(lst[k].desc)) {
+            return resolve(true);
+          }
+          spotifyWebHelperWinProcRegex.lastIndex = 0;
+        }
+        return resolve(false);
+      });
+    } else {
+      // SpotifyWebHelper starts with Spotify by default in Linux
+      return resolve(true);
+    }
+  });
 }
 
 function startSpotifyWebHelper() {
-    return new Promise(function (resolve, reject) {
-        var child = childProcess.spawn(getWebHelperPath(), {detached: true});
-        child.on('error', function (err) {
-            reject(new Error('Spotify is not installed. ' + err.message));
-        });
-        child.unref();
-        isSpotifyWebHelperRunning()
-            .then(function (isRunning) {
-                if (isRunning) {
-                    resolve(true);
-                } else {
-                    reject(new Error('Cannot start Spotify.'));
-                }
-            });
+  return new Promise(function (resolve, reject) {
+    var child = childProcess.spawn(getWebHelperPath(), { detached: true });
+    child.on('error', function (err) {
+      reject(new Error('Spotify is not installed. ' + err.message));
     });
+    child.unref();
+    isSpotifyWebHelperRunning().then(function (isRunning) {
+      if (isRunning) {
+        resolve(true);
+      } else {
+        reject(new Error('Cannot start Spotify.'));
+      }
+    });
+  });
 }
 
 function SpotifyWebHelper(opts) {
-    if (!(this instanceof SpotifyWebHelper)) {
-        return new SpotifyWebHelper(opts);
+  if (!(this instanceof SpotifyWebHelper)) {
+    return new SpotifyWebHelper(opts);
+  }
+
+  opts = opts || {};
+  var localPort = opts.port || START_HTTPS_PORT;
+
+  this.getCsrfToken = () => {
+    return new Promise((resolve, reject) => {
+      return getJSON({
+        url: this.generateSpotifyUrl('/simplecsrf/token.json'),
+        headers: ORIGIN_HEADER
+      })
+        .then(function (res) {
+          if (res.error) {
+            reject(new Error(res.error.message));
+          } else {
+            resolve(res.token);
+          }
+        })
+        .catch(reject);
+    });
+  };
+  this.ensureSpotifyWebHelper = function () {
+    return new Promise(function (resolve, reject) {
+      isSpotifyWebHelperRunning()
+        .then(isRunning => {
+          if (isRunning) {
+            return resolve();
+          }
+          return startSpotifyWebHelper();
+        })
+        .catch(function (err) {
+          reject(err);
+        });
+    });
+  };
+  this.generateSpotifyUrl = function (url, port = localPort) {
+    var protocol = 'https://';
+    if (port >= START_HTTP_PORT && port <= END_HTTP_PORT) {
+      protocol = 'http://';
     }
-
-    opts = opts || {};
-    var localPort = opts.port || START_HTTPS_PORT;
-
-    this.getCsrfToken = () => {
-        return new Promise((resolve, reject) => {
-            return getJSON({
-                url: this.generateSpotifyUrl('/simplecsrf/token.json'),
-                headers: ORIGIN_HEADER
-            })
-                .then(function (res) {
-                    if (res.error) {
-                        reject(new Error(res.error.message));
-                    } else {
-                        resolve(res.token);
-                    }
-                })
-                .catch(reject);
-        });
-    };
-    this.ensureSpotifyWebHelper = function () {
-        return new Promise(function (resolve, reject) {
-            isSpotifyWebHelperRunning()
-                .then(isRunning => {
-                    if (isRunning) {
-                        return resolve();
-                    }
-                    return startSpotifyWebHelper();
-                })
-                .catch(function (err) {
-                    reject(err);
-                });
-        });
-    };
-    this.generateSpotifyUrl = function (url, port = localPort) {
-        var protocol = 'https://';
-        if (port >= START_HTTP_PORT && port <= END_HTTP_PORT) {
-            protocol = 'http://';
-        }
-        return util.format('%s%s:%d%s', protocol, '127.0.0.1', port, url);
-    };
-    this.getOauthToken = function () {
-        return new Promise(function (resolve, reject) {
-            getJSON({
-                url: 'http://open.spotify.com/token'
-            })
-                .then(function (res) {
-                    resolve(res.t);
-                })
-                .catch(reject);
-        });
-    };
-    this.checkForError = status => {
-        if (!status.open_graph_state) {
-            this.player.emit('error', new Error('No user logged in'));
-            return true;
-        }
-        if (status.error) {
-            this.player.emit('error', new Error(status.error.message));
-            return true;
-        }
-        return false;
-    };
-    this.checkPort = function(port) {
-        return new Promise((resolve,reject) => {
-            getJSON({
-                url: this.generateSpotifyUrl('/service/version.json', port),
-                headers: ORIGIN_HEADER,
-                params: {
-                    'service': 'remote'
-                }
-            }).then(() => {
-                resolve(port);
-            }).catch(err => {
-            });
-        });
-    };
-    // Return the first successful port
-    this.checkPorts = function(startPort, endPort){
-        return Promise.race([...Array(endPort - startPort + 1).keys()].map(i => this.checkPort(startPort + i)));
+    return util.format('%s%s:%d%s', protocol, '127.0.0.1', port, url);
+  };
+  this.getOauthToken = function () {
+    return new Promise(function (resolve, reject) {
+      getJSON({
+        url: 'http://open.spotify.com/token'
+      })
+        .then(function (res) {
+          resolve(res.t);
+        })
+        .catch(reject);
+    });
+  };
+  this.checkForError = status => {
+    if (!status.open_graph_state) {
+      this.player.emit('error', new Error('No user logged in'));
+      return true;
     }
-    // Race to find the first succesful port
-    this.detectPort = function () {
-        const MAX_TIMEOUT = 5000;
-
-        return Promise.race([this.checkPorts(START_HTTPS_PORT, END_HTTPS_PORT),
-            this.checkPorts(START_HTTP_PORT, END_HTTP_PORT), new Promise((resolve, reject) =>
-                setTimeout(() => reject("No port found in range"), MAX_TIMEOUT)
-            )]).then(data => {localPort = data}).catch(err => {throw err;});
-    };
-
-    this.player = new EventEmitter();
-    this.player.pause = unpause => {
-        return getJSON({
-            url: this.generateSpotifyUrl('/remote/pause.json'),
-            headers: ORIGIN_HEADER,
-            params: {
-                returnafter: 1,
-                returnon: RETURN_ON.join(','),
-                oauth: this.oauthtoken,
-                csrf: this.csrftoken,
-                pause: !unpause
-            }
-        });
-    };
-    this.player.play = spotifyUri => {
-        if (!spotifyUri || (this.status && this.status.track && this.status.track.track_resource && this.status.track.track_resource.uri === spotifyUri)) {
-            this.player.pause(true);
-            return;
+    if (status.error) {
+      this.player.emit('error', new Error(status.error.message));
+      return true;
+    }
+    return false;
+  };
+  this.checkPort = function (port) {
+    return new Promise((resolve, reject) => {
+      getJSON({
+        url: this.generateSpotifyUrl('/service/version.json', port),
+        headers: ORIGIN_HEADER,
+        params: {
+          service: 'remote'
         }
-        return getJSON({
-            url: this.generateSpotifyUrl('/remote/play.json'),
-            headers: ORIGIN_HEADER,
-            params: {
-                returnafter: 1,
-                returnon: RETURN_ON.join(','),
-                oauth: this.oauthtoken,
-                csrf: this.csrftoken,
-                uri: spotifyUri,
-                context: spotifyUri
-            }
-        });
-    };
-    this.player.seekTo = seconds => {
-        this.status.playing_position = seconds; // eslint-disable-line camelcase
-        this.player.emit('seek', seconds);
-        return this.player.play(this.status.track.track_resource.uri + '#' + parseTime(seconds));
-    };
-    this.status = null;
-    var seekingInterval = null;
-    var startSeekingInterval = function () {
-        seekingInterval = setInterval(() => {
-            this.status.playing_position += SEEK_INTERVAL_LENGTH / 1000; // eslint-disable-line camelcase
-        }, SEEK_INTERVAL_LENGTH);
-    };
-    var stopSeekingInterval = function () {
-        clearInterval(seekingInterval);
-    };
-    this.compareStatus = function (status) {
-        let hasError = this.checkForError(status);
-        if (hasError) {
-            return;
-        }
-        this.player.emit('status-will-change', status);
-        let hasUri = track => track && track.track_resource && track.track_resource.uri;
-        if (hasUri(this.status.track) && hasUri(status.track) && this.status.track.track_resource.uri !== status.track.track_resource.uri) {
-            this.player.emit('track-will-change', status.track);
-            let hadListeners = this.player.emit('track-change', status.track);
-            if (hadListeners) {
-                if (process.emitWarning) {
-                    process.emitWarning(
-                        '\'track-change\' was renamed to \'track-will-change\', please update your listener',
-                        'DeprecationWarning'
-                    );
-                } else {
-                    console.warn('DeprecationWarning: \'track-change\' was renamed to \'track-will-change\', please update your listener')
-                }
-            }
-        }
-        if (this.status.playing !== status.playing) {
-            if (status.playing) {
-                this.player.emit('play');
-                startSeekingInterval.call(this);
-            } else {
-                if (Math.abs(status.playing_position - status.track.length) <= 1) {
-                    this.player.emit('end');
-                }
-                this.player.emit('pause');
-                stopSeekingInterval.call(this);
-            }
-        }
-        // Guarantee seekingInterval won't affect the seek event
-        if (Math.abs(this.status.playing_position - status.playing_position) > (2 * SEEK_INTERVAL_LENGTH) / 1000) {
-            this.player.emit('seek', status.playing_position);
-        }
-    };
-    var getStatus = () => {
-        return new Promise((resolve, reject) => {
-            getJSON({
-                url: this.generateSpotifyUrl('/remote/status.json'),
-                headers: ORIGIN_HEADER,
-                params: {
-                    returnafter: 1,
-                    returnon: RETURN_ON.join(','),
-                    oauth: this.oauthtoken,
-                    csrf: this.csrftoken
-                }
-            })
-                .then(res => {
-                    this.status = res;
-                    this.player.emit('ready');
-                    this.player.emit('status-will-change', res);
-                    if (res.playing) {
-                        this.player.emit('play');
-                        startSeekingInterval.call(this);
-                        this.player.emit('track-will-change', res.track);
-                        let hadListeners = this.player.emit('track-change', this.status.track);
-                        if (hadListeners) {
-                            if (process.emitWarning) {
-                                process.emitWarning(
-                                    '\'track-change\' was renamed to \'track-will-change\', please update your listener',
-                                    'DeprecationWarning'
-                                );
-                            } else {
-                                console.warn('DeprecationWarning: \'track-change\' was renamed to \'track-will-change\', please update your listener')
-                            }
-                        }
-                    }
-                    resolve();
-                })
-                .catch(reject);
-        });
-    };
-    var listen = () => {
-        getJSON({
-            url: this.generateSpotifyUrl('/remote/status.json'),
-            headers: KEEPALIVE_HEADER,
-            params: {
-                returnafter: DEFAULT_RETURN_AFTER,
-                returnon: RETURN_ON.join(','),
-                oauth: this.oauthtoken,
-                csrf: this.csrftoken
-            }
-        })
-            .then(res => {
-                this.compareStatus(res);
-                this.status = res;
-                let hasError = this.compareStatus(res);
-                if (hasError) {
-                    setTimeout(() => listen(), 5000);
-                } else {
-                    listen();
-                }
-            })
-            .catch(err => this.player.emit('error', err));
-    };
-
-    this.ensureSpotifyWebHelper()
-        .then(() => this.detectPort())
-        .then(() => this.getOauthToken())
-        .then(oauthtoken => {
-            this.oauthtoken = oauthtoken;
-            return this.getCsrfToken();
-        })
-        .then(csrftoken => {
-            this.csrftoken = csrftoken;
-            return getStatus();
-        })
+      })
         .then(() => {
-            return listen();
+          resolve(port);
+        })
+        .catch(err => { });
+    });
+  };
+  // Return the first successful port
+  this.checkPorts = function (startPort, endPort) {
+    return Promise.race(
+      [...Array(endPort - startPort + 1).keys()].map(i =>
+        this.checkPort(startPort + i)
+      )
+    );
+  };
+  // Race to find the first succesful port
+  this.detectPort = function () {
+    const MAX_TIMEOUT = 5000;
+
+    return Promise.race([
+      this.checkPorts(START_HTTPS_PORT, END_HTTPS_PORT),
+      this.checkPorts(START_HTTP_PORT, END_HTTP_PORT),
+      new Promise((resolve, reject) =>
+        setTimeout(() => reject('No port found in range'), MAX_TIMEOUT)
+      )
+    ])
+      .then(data => {
+        localPort = data;
+      })
+      .catch(err => {
+        throw err;
+      });
+  };
+
+  this.player = new EventEmitter();
+  this.player.pause = unpause => {
+    return getJSON({
+      url: this.generateSpotifyUrl('/remote/pause.json'),
+      headers: ORIGIN_HEADER,
+      params: {
+        returnafter: 1,
+        returnon: RETURN_ON.join(','),
+        oauth: this.oauthtoken,
+        csrf: this.csrftoken,
+        pause: !unpause
+      }
+    });
+  };
+  this.player.play = spotifyUri => {
+    if (
+      !spotifyUri ||
+      (this.status &&
+        this.status.track &&
+        this.status.track.track_resource &&
+        this.status.track.track_resource.uri === spotifyUri)
+    ) {
+      this.player.pause(true);
+      return;
+    }
+    return getJSON({
+      url: this.generateSpotifyUrl('/remote/play.json'),
+      headers: ORIGIN_HEADER,
+      params: {
+        returnafter: 1,
+        returnon: RETURN_ON.join(','),
+        oauth: this.oauthtoken,
+        csrf: this.csrftoken,
+        uri: spotifyUri,
+        context: spotifyUri
+      }
+    });
+  };
+  this.player.seekTo = seconds => {
+    this.status.playing_position = seconds; // eslint-disable-line camelcase
+    this.player.emit('seek', seconds);
+    return this.player.play(
+      this.status.track.track_resource.uri + '#' + parseTime(seconds)
+    );
+  };
+  this.status = null;
+  var seekingInterval = null;
+  var startSeekingInterval = function () {
+    seekingInterval = setInterval(() => {
+      this.status.playing_position += SEEK_INTERVAL_LENGTH / 1000; // eslint-disable-line camelcase
+    }, SEEK_INTERVAL_LENGTH);
+  };
+  var stopSeekingInterval = function () {
+    clearInterval(seekingInterval);
+  };
+  this.compareStatus = function (status) {
+    let hasError = this.checkForError(status);
+    if (hasError) {
+      return;
+    }
+    this.player.emit('status-will-change', status);
+    let hasUri = track =>
+      track && track.track_resource && track.track_resource.uri;
+    if (
+      hasUri(this.status.track) &&
+      hasUri(status.track) &&
+      this.status.track.track_resource.uri !== status.track.track_resource.uri
+    ) {
+      this.player.emit('track-will-change', status.track);
+      let hadListeners = this.player.emit('track-change', status.track);
+      if (hadListeners) {
+        if (process.emitWarning) {
+          process.emitWarning(
+            "'track-change' was renamed to 'track-will-change', please update your listener",
+            'DeprecationWarning'
+          );
+        } else {
+          console.warn(
+            "DeprecationWarning: 'track-change' was renamed to 'track-will-change', please update your listener"
+          );
+        }
+      }
+    }
+    if (this.status.playing !== status.playing) {
+      if (status.playing) {
+        this.player.emit('play');
+        startSeekingInterval.call(this);
+      } else {
+        if (Math.abs(status.playing_position - status.track.length) <= 1) {
+          this.player.emit('end');
+        }
+        this.player.emit('pause');
+        stopSeekingInterval.call(this);
+      }
+    }
+    // Guarantee seekingInterval won't affect the seek event
+    if (
+      Math.abs(this.status.playing_position - status.playing_position) >
+      2 * SEEK_INTERVAL_LENGTH / 1000
+    ) {
+      this.player.emit('seek', status.playing_position);
+    }
+  };
+
+  this.getStatus = () =>
+    getJSON({
+      url: this.generateSpotifyUrl('/remote/status.json'),
+      headers: ORIGIN_HEADER,
+      params: {
+        returnafter: 1,
+        returnon: RETURN_ON.join(','),
+        oauth: this.oauthtoken,
+        csrf: this.csrftoken
+      }
+    });
+
+  var getStatusAndEmit = () => {
+    return new Promise((resolve, reject) => {
+      this.getStatus()
+        .then(res => {
+          this.status = res;
+          this.player.emit('ready');
+          this.player.emit('status-will-change', res);
+          if (res.playing) {
+            this.player.emit('play');
+            startSeekingInterval.call(this);
+            this.player.emit('track-will-change', res.track);
+            let hadListeners = this.player.emit(
+              'track-change',
+              this.status.track
+            );
+            if (hadListeners) {
+              if (process.emitWarning) {
+                process.emitWarning(
+                  "'track-change' was renamed to 'track-will-change', please update your listener",
+                  'DeprecationWarning'
+                );
+              } else {
+                console.warn(
+                  "DeprecationWarning: 'track-change' was renamed to 'track-will-change', please update your listener"
+                );
+              }
+            }
+          }
+          resolve();
         })
         .catch(err => this.player.emit('error', err));
+    });
+  };
+  var listen = () => {
+    getJSON({
+      url: this.generateSpotifyUrl('/remote/status.json'),
+      headers: KEEPALIVE_HEADER,
+      params: {
+        returnafter: DEFAULT_RETURN_AFTER,
+        returnon: RETURN_ON.join(','),
+        oauth: this.oauthtoken,
+        csrf: this.csrftoken
+      }
+    })
+      .then(res => {
+        this.compareStatus(res);
+        this.status = res;
+        let hasError = this.compareStatus(res);
+        if (hasError) {
+          setTimeout(() => listen(), 5000);
+        } else {
+          listen();
+        }
+      })
+      .catch(err => this.player.emit('error', err));
+  };
+
+  this.ensureSpotifyWebHelper()
+    .then(() => this.detectPort())
+    .then(() => this.getOauthToken())
+    .then(oauthtoken => {
+      this.oauthtoken = oauthtoken;
+      return this.getCsrfToken();
+    })
+    .then(csrftoken => {
+      this.csrftoken = csrftoken;
+      return getStatusAndEmit();
+    })
+    .then(() => {
+      return listen();
+    })
+    .catch(err => this.player.emit('error', err));
 }
+
 // Possible error: need to wait until actually started / spotify not installed
 module.exports = SpotifyWebHelper;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "spotify-web-helper",
   "version": "1.13.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "buffer-shims": {
       "version": "1.0.0",
@@ -11,7 +12,12 @@
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.9",
+        "typedarray": "0.0.6"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -21,7 +27,14 @@
     "csv-parser": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-1.11.0.tgz",
-      "integrity": "sha1-zZLD9JiVo8FZFZEDXL++a1HFWrE="
+      "integrity": "sha1-zZLD9JiVo8FZFZEDXL++a1HFWrE=",
+      "requires": {
+        "generate-function": "1.1.0",
+        "generate-object-property": "1.2.0",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "ndjson": "1.5.0"
+      }
     },
     "decompress-response": {
       "version": "3.2.0",
@@ -36,12 +49,20 @@
     "each-async": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-      "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM="
+      "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+      "requires": {
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8="
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.9"
+      }
     },
     "generate-function": {
       "version": "1.1.0",
@@ -51,7 +72,10 @@
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-stream": {
       "version": "3.0.0",
@@ -61,7 +85,22 @@
     "got": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.0.0.tgz",
-      "integrity": "sha1-gtQ59nY82xyIIbejquJ4TIjDuNM="
+      "integrity": "sha1-gtQ59nY82xyIIbejquJ4TIjDuNM=",
+      "requires": {
+        "decompress-response": "3.2.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-plain-obj": "1.1.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "isurl": "1.0.0-alpha5",
+        "lowercase-keys": "1.0.0",
+        "p-cancelable": "0.2.0",
+        "p-timeout": "1.1.1",
+        "safe-buffer": "5.0.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -71,7 +110,10 @@
     "into-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-2.0.1.tgz",
-      "integrity": "sha1-25sANpRFPq4JHYpchMwRUHt4HTE="
+      "integrity": "sha1-25sANpRFPq4JHYpchMwRUHt4HTE=",
+      "requires": {
+        "from2": "2.3.0"
+      }
     },
     "is-object": {
       "version": "1.0.1",
@@ -106,7 +148,10 @@
     "isurl": {
       "version": "1.0.0-alpha5",
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0-alpha5.tgz",
-      "integrity": "sha1-d/oSL/8fMb4ntvFXZh+IWCuhzTY="
+      "integrity": "sha1-d/oSL/8fMb4ntvFXZh+IWCuhzTY=",
+      "requires": {
+        "is-object": "1.0.1"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -126,12 +171,23 @@
     "ndjson": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
-      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg="
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "5.0.1",
+        "minimist": "1.2.0",
+        "split2": "2.1.1",
+        "through2": "2.0.3"
+      }
     },
     "neat-csv": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/neat-csv/-/neat-csv-1.1.0.tgz",
-      "integrity": "sha1-NXpBL4S1WyEWAlmUXe86cL4wMBw="
+      "integrity": "sha1-NXpBL4S1WyEWAlmUXe86cL4wMBw=",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "csv-parser": "1.11.0",
+        "into-stream": "2.0.1"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -156,7 +212,10 @@
     "process-exists": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-exists/-/process-exists-1.0.0.tgz",
-      "integrity": "sha1-PkHbgeALT290REb2AQIhQtMkkWE="
+      "integrity": "sha1-PkHbgeALT290REb2AQIhQtMkkWE=",
+      "requires": {
+        "ps-list": "2.1.2"
+      }
     },
     "process-nextick-args": {
       "version": "1.0.7",
@@ -166,12 +225,25 @@
     "ps-list": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-2.1.2.tgz",
-      "integrity": "sha1-iRNbK92fuVHQrCRvBXtgQcj96vI="
+      "integrity": "sha1-iRNbK92fuVHQrCRvBXtgQcj96vI=",
+      "requires": {
+        "each-async": "1.1.1",
+        "tasklist": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g="
+      "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+      "requires": {
+        "buffer-shims": "1.0.0",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "1.0.1",
+        "util-deprecate": "1.0.2"
+      }
     },
     "safe-buffer": {
       "version": "5.0.1",
@@ -191,22 +263,36 @@
     "split2": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.1.1.tgz",
-      "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A="
+      "integrity": "sha1-eh9VHhdqkOzTNF9yRqDP4XXvT9A=",
+      "requires": {
+        "through2": "2.0.3"
+      }
     },
     "string_decoder": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
     },
     "tasklist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tasklist/-/tasklist-1.1.0.tgz",
-      "integrity": "sha1-0g4OpENsJUV4rDqsvMAbQnzbr40="
+      "integrity": "sha1-0g4OpENsJUV4rDqsvMAbQnzbr40=",
+      "requires": {
+        "neat-csv": "1.1.0",
+        "sec": "1.0.0"
+      }
     },
     "through2": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4="
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.2.9",
+        "xtend": "4.0.1"
+      }
     },
     "timed-out": {
       "version": "4.0.1",
@@ -221,7 +307,10 @@
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM="
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",


### PR DESCRIPTION
I needed to be able to "refresh" the status as I'm changing the track from another package too.
This PR is adding getStatus to the object that way you can get a "fresh" status if needed.

Sorry for the prettifying in the git diff. You might want to add a eslint config so the code can be parsed automatically.

Useful line start here: https://github.com/onetune/spotify-web-helper/compare/master...vincentaudebert:feature/open-getstatus?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR344